### PR TITLE
Add more testing before module.exports

### DIFF
--- a/re-tree.js
+++ b/re-tree.js
@@ -65,7 +65,7 @@
         };
     }
 
-    if (module && module.exports) {
+    if (!!module && !!(module.exports)) {
         module.exports = {
             test: test,
             exec: exec

--- a/re-tree.js
+++ b/re-tree.js
@@ -65,7 +65,7 @@
         };
     }
 
-    if (!!module) {
+    if (typeof module !== 'undefined' && module.exports) {
         module.exports = {
             test: test,
             exec: exec

--- a/re-tree.js
+++ b/re-tree.js
@@ -65,7 +65,7 @@
         };
     }
 
-    if (typeof module !== 'undefined' && module.exports) {
+    if (module && module.exports) {
         module.exports = {
             test: test,
             exec: exec


### PR DESCRIPTION
I ran into an issue where `re-tree` was causing interacting with other libraries and triggering their "node specific" code paths.

This change checks that `modules.exports` has been initialized before setting it.